### PR TITLE
unset google api key for unstable

### DIFF
--- a/terraform/ecs-service-bmlt-unstable.tf
+++ b/terraform/ecs-service-bmlt-unstable.tf
@@ -16,10 +16,6 @@ resource "aws_ecs_task_definition" "bmlt_unstable" {
         ]
         environment = [
           {
-            name  = "GKEY",
-            value = var.GOOGLE_API_KEY
-          },
-          {
             name  = "MEETING_STATES_AND_PROVINCES",
             value = "CT,MA,NH,NJ,NY,PA,VT"
           },


### PR DESCRIPTION
now that both latest/unstable are using new UI we can have one not have google key to test Open Street Maps and Nominatim