### PR TITLE
fix method signature, deprecation notice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ dev: zip ## Docker Compose Up
 
 .PHONY: test
 test:  ## Runs PHP Tests
-	$(TEST_PREFIX) php artisan test --parallel --recreate-databases --coverage-clover coverage.xml
+	$(TEST_PREFIX) php artisan test --parallel --recreate-databases --display-deprecations --coverage-clover coverage.xml
 # 	$(TEST_PREFIX) vendor/bin/phpunit tests/Feature/Admin/ServiceBodyPartialUpdateTest.php
 # 	$(TEST_PREFIX) vendor/bin/phpunit --filter testUpdateServiceBodyAsServiceBodyAdmin tests/Feature/Admin/ServiceBodyPartialUpdateTest.php
 

--- a/src/app/LegacyConfig.php
+++ b/src/app/LegacyConfig.php
@@ -7,7 +7,7 @@ class LegacyConfig
     private static ?array $config = null;
     private static bool $configLoaded = false;
 
-    public static function get(string $key = null, $default = null)
+    public static function get(?string $key = null, $default = null)
     {
         if (!self::$configLoaded) {
             self::loadConfig();


### PR DESCRIPTION
PHP 8.4 Made implicit nullable parameters deprecated, Now requires explicit nullable declaration. nullable types were introduced in 7.1