### PR TITLE
remove bad sort on group by query in naws export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Added new user interface implemented in Svelte.  This includes a brand-new UI code base and various improvements. It is mostly backward compatible, except as noted here:
   - Dropped support for the installer wizard -- see `installation/README.md` for new directions.
   - Deprecated the auto-config parameter `$default_minute_interval` (now just set to 5 minutes).
+* Fixed a bug that prevented the NAWS Export from working with newer versions of MySQL.
 
 ## 3.1.2 (May 2, 2025)
 * PHP 8.2 and higher are now required. PHP 8.1 is no longer supported.

--- a/src/app/Repositories/ChangeRepository.php
+++ b/src/app/Repositories/ChangeRepository.php
@@ -27,6 +27,8 @@ class ChangeRepository implements ChangeRepositoryInterface
         return $this->getBuilder($startDate, $endDate, $meetingId, $serviceBodyId, $changeTypes)
             ->selectRaw('MAX(change_date) as change_date, COALESCE(before_id_bigint, after_id_bigint) as meeting_id')
             ->groupByRaw('COALESCE(before_id_bigint, after_id_bigint)')
+            ->reorder()
+            ->orderByDesc('change_date')
             ->get()
             ->mapWithKeys(fn ($row, $_) => [$row->meeting_id => strtotime($row->change_date)]);
     }


### PR DESCRIPTION
Fixes https://github.com/bmlt-enabled/bmlt-server/issues/1254, which only impacted servers running mysql (not mariadb).