### PR TITLE
Correção na rotina de inclusão de formatos

### DIFF
--- a/src/legacy/local_server/server_admin/c_comdef_admin_ajax_handler.class.php
+++ b/src/legacy/local_server/server_admin/c_comdef_admin_ajax_handler.class.php
@@ -489,7 +489,8 @@ class c_comdef_admin_ajax_handler
 
                     if (!$shared_id) {
                         $shared_id = intval($format_data['shared_id']);
-                        $format_type = $format_data['type'];
+                        if (isset($format_data['type']))
+                            $format_type = $format_data['type'];
                     } else {
                         if ($shared_id != intval($format_data['shared_id'])) {  // This should never happen.
                             $the_objects_to_be_changed = null;


### PR DESCRIPTION
Correção na tela de inclusão de formatos quando o usuário não informa o campo format_type, que já é definido como default FC1 na linha 469